### PR TITLE
ardronelib: add pkg-config compatibility.

### DIFF
--- a/ardronelib/CMakeLists.txt
+++ b/ardronelib/CMakeLists.txt
@@ -71,6 +71,36 @@ add_custom_target(uninstall
 )
 
 
+## pkg-config
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${prefix}/lib/jderobot/ardrone)
+
+set(includedir ${prefix}/include/jderobot/ardrone/FFMPEG/Includes)
+configure_file(ffmpeg-0.8.pc.in ffmpeg-0.8.pc)
+
+set(VERSION ${ARDRONE_SDK_FLAVOR})
+set(includedir
+	${prefix}/include/jderobot/ardrone/
+	${prefix}/include/jderobot/ardrone/Soft/Common
+	${prefix}/include/jderobot/ardrone/Soft/Lib
+	${prefix}/include/jderobot/ardrone/VP_SDK
+	${prefix}/include/jderobot/ardrone/VP_SDK/VP_Os/linux
+	${prefix}/include/jderobot/ardrone/VP_SDK/VP_Api
+)
+configure_file(ardronelib.pc.in ardronelib.pc)
+
+install(FILES
+	"${CMAKE_BINARY_DIR}/ardronelib.pc"
+	"${CMAKE_BINARY_DIR}/ffmpeg-0.8.pc"
+	DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/"
+)
+
+add_custom_command(TARGET uninstall
+	WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/"
+	COMMAND ${CMAKE_COMMAND} -E remove ardronelib.pc ffmpeg-0.8.pc
+)
+
+
 ## ---------------------------
 
 # CPACK patch #1: undesired executables

--- a/ardronelib/ardronelib.pc.in
+++ b/ardronelib/ardronelib.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: ardronelib
+Description: ArDrone SDK library
+Version: @VERSION@
+Libs: -L${libdir} -lpc_ardrone -lpc_ardrone_notool -lsdk -lvlib
+Cflags: -I${includedir}
+Requires: ffmpeg-0.8

--- a/ardronelib/ffmpeg-0.8.pc.in
+++ b/ardronelib/ffmpeg-0.8.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: ffmpeg-0.8
+Description: FFMPEG library
+Version: 0.8
+Libs: -L${libdir} -lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswscale
+Cflags: -I${includedir}


### PR DESCRIPTION
# Proposal for solve scan of ardronelib deps

Use **pkg-config** to find ardronelib and embedded ffmpeg.
This action allows to use ffmpeg from plain g++ without split .deb neither think on package, path and name collision.

```
$ pkg-config --libs ffmpeg-0.8
-L/usr/local/lib/jderobot/ardrone -lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswscale
```

It also allows hierarchical dependencies:
`Requires: ffmpeg-0.8`

```
$ pkg-config --libs ardronelib
-L/usr/local/lib/jderobot/ardrone -lpc_ardrone -lpc_ardrone_notool -lsdk -lvlib -lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswscale 
```

_More explanations at commit message._
